### PR TITLE
feat: display camera messages with bootstrap alerts

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover"
   />
   <title>Doc Cam Viewer</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -57,14 +58,15 @@
   </header>
 
   <main id="stage">
+    <div id="hint" class="alert alert-info text-center" role="alert">Click “Allow” when the browser asks for camera access.</div>
     <div id="videoWrap">
       <video id="video" autoplay playsinline></video>
       <canvas id="overlay"></canvas>
     </div>
-    <div id="hint" class="hint">Click “Allow” when the browser asks for camera access.</div>
   </main>
 
   <footer class="footer">A DocCam by Alexander Libby, an Infinity Technology Support creation. <span id="year"></span></footer>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -133,9 +133,9 @@ async function startStream(deviceId = undefined) {
     const stream = await navigator.mediaDevices.getUserMedia(constraints);
     video.srcObject = stream;
     currentStream = stream;
-    hint.classList.remove("error");
     hint.textContent = defaultHint;
-    hint.style.display = "none";
+    hint.classList.remove("alert-danger");
+    hint.classList.add("alert-info", "d-none");
     // Determine the actual device ID of the stream
     const track = stream.getVideoTracks()[0];
     currentDeviceId = track.getSettings().deviceId || deviceId || null;
@@ -150,8 +150,8 @@ async function startStream(deviceId = undefined) {
   } catch (err) {
     console.error(err);
     hint.textContent = "Camera access failed. Check permissions or device.";
-    hint.classList.add("error");
-    hint.style.display = "block";
+    hint.classList.remove("alert-info", "d-none");
+    hint.classList.add("alert-danger");
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -135,25 +135,6 @@ button.active { outline: 2px solid var(--accent); }
   filter: invert(1) hue-rotate(180deg);
 }
 
-.hint {
-  position: absolute; bottom: 10px; left: 50%;
-  transform: translateX(-50%);
-  color: var(--muted); font-size: 13px;
-  background: #0b0d12d0; padding: 6px 10px; border-radius: 8px;
-  border: 1px solid #1e2333;
-}
-
-.hint.error {
-  top: 50%;
-  bottom: auto;
-  transform: translate(-50%, -50%);
-  font-size: 16px;
-  font-weight: bold;
-  color: #fff;
-  background: #b00020;
-  border-color: #ff5a5f;
-  padding: 10px 16px;
-}
 
 .menu-toggle {
   position: fixed;


### PR DESCRIPTION
## Summary
- Add Bootstrap and convert camera permission hints into `alert` banner
- Remove custom hint CSS in favor of Bootstrap styling
- Toggle alert classes in script to show failure or hide on success

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c63ec727388332a60d4cce007a1c8d