### PR TITLE
docs: add privacy notice and GitHub link

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,14 @@ Possible ways to extend or adjust DocCam:
 
 - **Styling** – Update `style.css` to change layout, colors, button styles, etc.  
 - **Image formats / capture options** – Enhance `script.js` to support different file formats (PNG, JPEG, etc.), adjust resolution, compression quality.  
-- **User interface** – Add features like cropping, zoom, rotate, etc.  
-- **Saving/exporting** – Integrate download options or save to cloud/local storage.  
+- **User interface** – Add features like cropping, zoom, rotate, etc.
+- **Saving/exporting** – Integrate download options or save to cloud/local storage.
+
+---
+
+## Privacy Notice
+
+DocCam runs entirely within your browser. Camera access and image capture stay on your device, and **no data is sent back to any server**.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
 
   <div id="hint" class="alert alert-info text-center" role="alert">Click “Allow” when the browser asks for camera access.</div>
 
-  <footer class="footer">A DocCam by Alexander Libby, an Infinity Technology Support creation. <span id="year"></span></footer>
+  <footer class="footer">A DocCam by Alexander Libby, an Infinity Technology Support creation. <span id="year"></span> | <a href="https://github.com/linuts/DocCam">GitHub</a></footer>
   <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- document that DocCam sends no data back to servers
- link GitHub repository from website footer instead of README

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f83852e08332bdf1b7ed70b45658